### PR TITLE
プログラミング言語名の大文字小文字の表記を、正式なものに合わせてみました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ AM2:00が過ぎると加速する  現実逃避ゆえの妄想タイム
 アルゴリズム  変えずに済む…そんなわけない  常備したエナジードリンク底をつく
 
 ``Call&Response``
-Java (Java) scala (scala)  JS  php
-Unity(Unity) cobol (cobol) Ruby .NET ×2
+Java (Java) Scala (Scala)  JS  php
+Unity (Unity) COBOL (COBOL) Ruby .NET　×2
 
 ``Bメロ``
 みんな使う銀行システムも  今が旬のゲームアプリも
@@ -54,8 +54,8 @@ Unity(Unity) cobol (cobol) Ruby .NET ×2
 絶え間なく 答えなく タイピング everybody funky right now 
 
 ``Call&Response``
-Java (Java) scala (scala)  JS  php
-Unity(Unity) cobol (cobol) Ruby .NET　×2
+Java (Java) Scala (Scala)  JS  php
+Unity (Unity) COBOL (COBOL) Ruby .NET　×2
 
 
 ## song by missato


### PR DESCRIPTION
先日は素敵な歌声をありがとうございました。

なんとなく気になったので、プログラミング言語の名称 `Scala` と `COBOL` のアルファベットの大文字小文字の表記を正式と思われるものに書き換えてみました。

本質的には問題ないとも言えるのですけど、せっかくなら意識が透明に歌に向かった方が好ましいのかなって思いまして。好ましそうでしたら取り込んでみてくださいませ。